### PR TITLE
Separate prefill and decode requests also for causal_conv1d layer

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -397,7 +397,6 @@ class MambaMixer2(CustomOp):
         has_prefill = num_prefills > 0
         has_decode = num_decodes > 0
 
-        seq_len, _ = hidden_states.shape
         groups_time_state_size = self.n_groups * self.ssm_state_size
 
         # 1. Gated MLP's linear projection


### PR DESCRIPTION
Split input for causal_conv1d the same way as done with Mamba2 SSD triton kernels.


