### PR TITLE
Intermediate Tensor Block Alignment And other Optimizations

### DIFF
--- a/vllm/model_executor/layers/mamba/fused_ops/fused_block_scan.py
+++ b/vllm/model_executor/layers/mamba/fused_ops/fused_block_scan.py
@@ -209,8 +209,6 @@ def fused_block_scan_v1_kernel(
         prev_state = tl.load(prev_states_ptrs,
                              mask=(mask_d[:, None] & mask_s[None, :]),
                              other=0.0)
-    # DEBUG
-    # prev_state = tl.zeros((BLOCK_SIZE_D, BLOCK_SIZE_S), dtype=tl.float32)
 
     pid_g = pid_h // nheads_ngroups_ratio  # group idx
     t0_range = tl.arange(0, BLOCK_SIZE_T0)
@@ -245,8 +243,8 @@ def fused_block_scan_v1_kernel(
     C_ptrs = C_ptr_base + (
         offs_t0_global[:, None] * stride_C_t + offs_s[None, :] * stride_C_s
     )  # (BLOCK_SIZE_T0, dstate)
-    C = tl.load(C_ptrs, mask=(mask_t0[:, None] & mask_s[None, :]),
-                other=0.0).to(tl.float32)
+    C = tl.load(C_ptrs, mask=(mask_t0[:, None] & mask_s[None, :]), other=0.0)
+    prev_state = prev_state.to(C.dtype)
     acc += (tl.dot(C, prev_state.T) * tl.exp(dA_cumsum_t0[:, None])
             )  #(BLOCK_SIZE_T0, headdim)
 

--- a/vllm/model_executor/layers/mamba/fused_ops/fused_block_state_bmm.py
+++ b/vllm/model_executor/layers/mamba/fused_ops/fused_block_state_bmm.py
@@ -4,10 +4,7 @@
 
 import torch
 
-# from vllm.model_executor.layers.mamba.ops.mamba_ssm import softplus
 from vllm.triton_utils import tl, triton
-
-from .standalone_block_cumsum import align
 
 
 # from .utils import generate_autotune_combinations
@@ -24,6 +21,7 @@ from .standalone_block_cumsum import align
 #         ),
 #     key=[],
 # )
+#Triton autotuning for function fused_block_state_bmm_kernel finished after 126.16s; best config selected: BLOCK_SIZE_TT: 64, BLOCK_SIZE_D: 64, BLOCK_SIZE_S: 64, BLOCK_SIZE_T0: 16, BLOCK_SIZE_T1: 16, num_warps: 2, num_ctas: 1, num_stages: 3, num_buffers_warp_spec: 0, num_consumer_groups: 0, reg_dec_producer: 0, reg_inc_consumer: 0, maxnreg: None;
 # Best found on H100 # fused
 @triton.autotune(
     configs=[
@@ -37,16 +35,16 @@ from .standalone_block_cumsum import align
             },
             num_warps=2,
             num_stages=3),
-        triton.Config(
-            {
-                'BLOCK_SIZE_TT': 64,
-                'BLOCK_SIZE_D': 64,
-                'BLOCK_SIZE_S': 64,
-                'BLOCK_SIZE_T0': 16,
-                'BLOCK_SIZE_T1': 16,
-            },
-            num_warps=4,
-            num_stages=3),
+        # triton.Config(
+        #     {
+        #         'BLOCK_SIZE_TT': 128,
+        #         'BLOCK_SIZE_D': 64,
+        #         'BLOCK_SIZE_S': 64,
+        #         'BLOCK_SIZE_T0': 16,
+        #         'BLOCK_SIZE_T1': 16,
+        #     },
+        #     num_warps=4,
+        #     num_stages=3),
     ],
     key=[],
 )
@@ -58,6 +56,7 @@ def fused_block_state_bmm_kernel(
     B_ptr,
     C_ptr,
     block_cu_seqlens_ptr,
+    block_packed_cu_seqlens_ptr,
     # Outputs
     dA_cumsum_ptr,
     block_states_ptr,
@@ -82,6 +81,7 @@ def fused_block_state_bmm_kernel(
     stride_C_g: tl.constexpr,
     stride_C_s: tl.constexpr,
     stride_block_cu_seqlens_n: tl.constexpr,
+    stride_block_packed_cu_seqlens_n: tl.constexpr,
     stride_block_states_n: tl.constexpr,
     stride_block_states_h: tl.constexpr,
     stride_block_states_d: tl.constexpr,
@@ -117,7 +117,12 @@ def fused_block_state_bmm_kernel(
 
     # Load block start and end offset
     t_start = tl.load(block_cu_seqlens_ptr + pid_n * stride_block_cu_seqlens_n)
-    align_t_start = align(t_start) if ALIGN_BLOCKS else t_start
+    align_t_start = t_start
+    if ALIGN_BLOCKS:
+        align_t_start = tl.load(block_packed_cu_seqlens_ptr +
+                                pid_n * stride_block_packed_cu_seqlens_n)
+        align_t_start = tl.multiple_of(
+            align_t_start, 4)  # not sure if the hint works in if block
 
     t_end = tl.load(block_cu_seqlens_ptr +
                     (pid_n + 1) * stride_block_cu_seqlens_n)
@@ -248,6 +253,7 @@ def fused_block_state_bmm(
     block_size,
     # metadata
     block_cu_seqlens,  # (nblocks+1,)
+    block_packed_cu_seqlens=None,  # (nblocks+1,)
     states_in_fp32=True,
     FUSED_COMPUTE_CB=True,
     align_blocks=False,
@@ -263,6 +269,8 @@ def fused_block_state_bmm(
     assert dA_cumsum.shape == (nheads, aligned_seqlen)
     assert C.shape == (seqlen, ngroups, dstate)
     assert C.shape == B.shape
+    if align_blocks:
+        assert block_packed_cu_seqlens.shape == block_cu_seqlens.shape
 
     device = x.device
     dtype = x.dtype
@@ -293,6 +301,7 @@ def fused_block_state_bmm(
             B_ptr=B,
             C_ptr=C,
             block_cu_seqlens_ptr=block_cu_seqlens,
+            block_packed_cu_seqlens_ptr=block_packed_cu_seqlens,
             block_states_ptr=block_states,
             CB_ptr=CB,
             block_size=block_size,
@@ -313,6 +322,8 @@ def fused_block_state_bmm(
             stride_C_g=C.stride(1),
             stride_C_s=C.stride(2),
             stride_block_cu_seqlens_n=block_cu_seqlens.stride(0),
+            stride_block_packed_cu_seqlens_n=(block_packed_cu_seqlens.stride(0)
+                                              if align_blocks else 0),
             stride_block_states_n=block_states.stride(0),
             stride_block_states_h=block_states.stride(1),
             stride_block_states_d=block_states.stride(2),

--- a/vllm/model_executor/layers/mamba/fused_ops/fused_block_state_bmm.py
+++ b/vllm/model_executor/layers/mamba/fused_ops/fused_block_state_bmm.py
@@ -285,9 +285,10 @@ def fused_block_state_bmm(
         dtype=torch.float32 if states_in_fp32 else dtype,
         device=device)
 
-    CB = (torch.empty((nblocks, ngroups, block_size, block_size),
-                      dtype=torch.float32,
-                      device=device) if FUSED_COMPUTE_CB else None)
+    CB = (torch.full((nblocks, ngroups, block_size, block_size),
+                     float('-inf'),
+                     dtype=torch.float32,
+                     device=device) if FUSED_COMPUTE_CB else None)
     CB_strides = (0, 0, 0, 0) if CB is None else (CB.stride(0), CB.stride(1),
                                                   CB.stride(2), CB.stride(3))
     # Launch grid

--- a/vllm/model_executor/layers/mamba/fused_ops/standalone_state_passing.py
+++ b/vllm/model_executor/layers/mamba/fused_ops/standalone_state_passing.py
@@ -35,12 +35,20 @@ from vllm.triton_utils import tl, triton
 # )
 @triton.autotune(
     configs=[
-        triton.Config({
-            'BLOCK_SIZE_D': 16,
-            'BLOCK_SIZE_S': 64,
-        },
-                      num_warps=4,
-                      num_stages=5),
+        triton.Config(
+            {
+                'BLOCK_SIZE_D': 16,  # best
+                'BLOCK_SIZE_S': 64,
+            },
+            num_warps=4,
+            num_stages=5),
+        triton.Config(
+            {
+                'BLOCK_SIZE_D': 32,  # best for non aligned?
+                'BLOCK_SIZE_S': 64,
+            },
+            num_warps=4,
+            num_stages=5),
     ],
     key=[],
 )

--- a/vllm/model_executor/layers/mamba/fused_ops/standalone_state_passing.py
+++ b/vllm/model_executor/layers/mamba/fused_ops/standalone_state_passing.py
@@ -182,6 +182,7 @@ def state_passing(
     block_packed_cu_seqlens=None,  # (nblocks+1,)
     return_prev_states=True,
     align_blocks=False,
+    out_dtype=None,
 ):
 
     nheads, _ = dA_cumsum.shape
@@ -199,10 +200,11 @@ def state_passing(
     device = dA_cumsum.device
 
     # Allocate outputs
-    prev_states = (torch.empty_like(block_states)
+    out_dtype = block_states.dtype if out_dtype is None else out_dtype
+    prev_states = (torch.empty_like(block_states, dtype=out_dtype)
                    if return_prev_states else None)
     final_states = torch.empty((batch, nheads, headdim, dstate),
-                               dtype=block_states.dtype,
+                               dtype=out_dtype,
                                device=device)
     prev_state_strides = ((0, 0, 0, 0) if prev_states is None else
                           (prev_states.stride(0), prev_states.stride(1),

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -26,6 +26,9 @@ class Mamba2Metadata:
     block_req_idx: torch.Tensor
     block_ntokens: torch.Tensor
 
+    block_packed_cu_seqlens: torch.Tensor
+    packed_seqlen: int
+
 
 def get_platform_metadata_classes() -> tuple[type[AttentionMetadata], ...]:
     """Returns the appropriate metadata classes for the current platform."""
@@ -78,8 +81,10 @@ def _query_start_loc_to_chunk_indices_offsets(query_start_loc: torch.Tensor,
     return chunk_indices, chunk_offsets
 
 
-def _get_block_ranges(query_start_loc: torch.Tensor, block_size: int,
-                      sum_seqlens: int):
+def _get_block_ranges(query_start_loc: torch.Tensor,
+                      block_size: int,
+                      sum_seqlens: int,
+                      pack_size: int = 4):
     device = query_start_loc.device
     seqlens = torch.diff(query_start_loc)
     nreqs = len(seqlens)
@@ -114,6 +119,13 @@ def _get_block_ranges(query_start_loc: torch.Tensor, block_size: int,
         torch.cumsum(block_ntokens, dim=0),
     ])
 
+    # metadata for packed fp32 vectorization
+    block_packed_fill = (pack_size - block_ntokens % pack_size) % pack_size
+    block_packed_cu_seqlens = torch.cat([
+        torch.zeros([1], dtype=torch.int32, device=device),
+        torch.cumsum(block_packed_fill, dim=0),
+    ]) + block_cu_seqlens
+
     # request level metadata
     req_cu_nblocks = torch.cat([
         torch.zeros([1], dtype=torch.int32, device=device),
@@ -122,7 +134,8 @@ def _get_block_ranges(query_start_loc: torch.Tensor, block_size: int,
     # sanity check
     assert block_cu_seqlens[-1] == sum_seqlens
 
-    return req_cu_nblocks, block_cu_seqlens, block_req_idx, block_ntokens
+    return (req_cu_nblocks, block_cu_seqlens, block_req_idx, block_ntokens,
+            block_packed_cu_seqlens)
 
 
 def prepare_mamba2_metadata(
@@ -139,6 +152,7 @@ def prepare_mamba2_metadata(
     chunk_indices, chunk_offsets = None, None
     req_cu_nblocks, block_cu_seqlens, block_req_idx, block_ntokens = \
         None, None, None, None
+    block_packed_cu_seqlens = None
     # Need flags to indicate if there are initial states
     # currently we really only support the FlashAttention backend
     has_initial_states = None
@@ -171,7 +185,8 @@ def prepare_mamba2_metadata(
                 _query_start_loc_to_chunk_indices_offsets(
                 query_start_loc, chunk_size, num_prefill_tokens)
 
-        req_cu_nblocks, block_cu_seqlens, block_req_idx, block_ntokens = \
+        req_cu_nblocks, block_cu_seqlens, block_req_idx, \
+            block_ntokens, block_packed_cu_seqlens = \
             _get_block_ranges(query_start_loc, chunk_size, num_prefill_tokens)
 
     return Mamba2Metadata(has_initial_states=has_initial_states,
@@ -183,4 +198,7 @@ def prepare_mamba2_metadata(
                           req_cu_nblocks=req_cu_nblocks,
                           block_cu_seqlens=block_cu_seqlens,
                           block_req_idx=block_req_idx,
-                          block_ntokens=block_ntokens)
+                          block_ntokens=block_ntokens,
+                          block_packed_cu_seqlens=block_packed_cu_seqlens,
+                          packed_seqlen=block_packed_cu_seqlens[-1]
+                          if block_packed_cu_seqlens is not None else -1)

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -200,5 +200,5 @@ def prepare_mamba2_metadata(
                           block_req_idx=block_req_idx,
                           block_ntokens=block_ntokens,
                           block_packed_cu_seqlens=block_packed_cu_seqlens,
-                          packed_seqlen=block_packed_cu_seqlens[-1]
+                          packed_seqlen=block_packed_cu_seqlens[-1].item()
                           if block_packed_cu_seqlens is not None else -1)

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -602,6 +602,19 @@ class MambaMixer2(CustomOp):
                 block_packed_cu_seqlens,
             )
 
+            final_states, prev_states = state_passing(
+                dA_cumsum=dA_cumsum,
+                block_states=block_states,
+                initial_states=initial_states,
+                block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
+                block_req_idx=mamba2_metadata.block_req_idx,
+                req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
+                return_prev_states=True,
+                align_blocks=align_blocks,
+                block_packed_cu_seqlens=mamba2_metadata.
+                block_packed_cu_seqlens,
+            )
+
             def restore_packed(x, block_cu_seqlens, block_ntokens):
                 out = []
                 xT = x.T
@@ -620,17 +633,6 @@ class MambaMixer2(CustomOp):
             # print(f"{dA_cumsum[-1]=}, {dA_cumsum.shape=}")
 
             align_blocks = False
-
-            final_states, prev_states = state_passing(
-                dA_cumsum=dA_cumsum,
-                block_states=block_states,
-                initial_states=initial_states,
-                block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                block_req_idx=mamba2_metadata.block_req_idx,
-                req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
-                return_prev_states=True,
-                align_blocks=align_blocks,
-            )
 
             # _, scan_output, _ = fused_block_scan(
             #     x=x_p,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -610,6 +610,7 @@ class MambaMixer2(CustomOp):
                 block_req_idx=mamba2_metadata.block_req_idx,
                 req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
                 return_prev_states=True,
+                out_dtype=C_p.dtype,
                 align_blocks=align_blocks,
                 block_packed_cu_seqlens=mamba2_metadata.
                 block_packed_cu_seqlens,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -579,7 +579,6 @@ class MambaMixer2(CustomOp):
                 A=self.A,
                 block_size=block_size,
                 block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                block_ntokens=mamba2_metadata.block_ntokens,
                 dt_bias=self.dt_bias,
                 dt_softplus=True,
                 align_blocks=align_blocks,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -587,6 +587,21 @@ class MambaMixer2(CustomOp):
                 packed_seqlen=mamba2_metadata.packed_seqlen,
             )
 
+            block_states, CB = fused_block_state_bmm(
+                x=x_p,
+                dt=dt_out,
+                dA_cumsum=dA_cumsum,
+                B=B_p,
+                C=C_p,
+                block_size=block_size,
+                block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
+                states_in_fp32=True,
+                FUSED_COMPUTE_CB=True,
+                align_blocks=align_blocks,
+                block_packed_cu_seqlens=mamba2_metadata.
+                block_packed_cu_seqlens,
+            )
+
             def restore_packed(x, block_cu_seqlens, block_ntokens):
                 out = []
                 xT = x.T
@@ -605,18 +620,6 @@ class MambaMixer2(CustomOp):
             # print(f"{dA_cumsum[-1]=}, {dA_cumsum.shape=}")
 
             align_blocks = False
-            block_states, CB = fused_block_state_bmm(
-                x=x_p,
-                dt=dt_out,
-                dA_cumsum=dA_cumsum,
-                B=B_p,
-                C=C_p,
-                block_size=block_size,
-                block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                states_in_fp32=True,
-                FUSED_COMPUTE_CB=True,
-                align_blocks=align_blocks,
-            )
 
             final_states, prev_states = state_passing(
                 dA_cumsum=dA_cumsum,

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -565,7 +565,10 @@ class MambaMixer2(CustomOp):
 
             max_fused = False
             if max_fused:  # 2 kernel control flow
-                # BUGGED
+
+                # NOTE: pay extra attention when changing block sizes
+                #       -- it can make CB decomposition fail
+                # TODO: Make CB decomposition more flexible
                 dA_cumsum, dt_out, block_states, CB = fused_block_ssd(
                     x=x_p,
                     dt=dt_p,
@@ -579,75 +582,6 @@ class MambaMixer2(CustomOp):
                     states_in_fp32=True,
                     FUSED_COMPUTE_CB=True,
                 )
-                # BUG: CB result is wrong
-
-                align_blocks = False
-                # dA_cumsum_x, dt_out_x = block_cumsum(
-                #     dt=dt_p,
-                #     A=self.A,
-                #     block_size=block_size,
-                #     block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                #     dt_bias=self.dt_bias,
-                #     dt_softplus=True,
-                #     align_blocks=align_blocks,
-                #     block_packed_cu_seqlens=mamba2_metadata.
-                #     block_packed_cu_seqlens,
-                #     packed_seqlen=mamba2_metadata.packed_seqlen,
-                # )
-
-                _, CB_x = fused_block_state_bmm(
-                    x=x_p,
-                    dt=dt_out,
-                    dA_cumsum=dA_cumsum,
-                    B=B_p,
-                    C=C_p,
-                    block_size=block_size,
-                    block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                    states_in_fp32=True,
-                    FUSED_COMPUTE_CB=True,
-                    align_blocks=align_blocks,
-                    block_packed_cu_seqlens=mamba2_metadata.
-                    block_packed_cu_seqlens,
-                )
-                # print(f"{dA_cumsum[-1, -1]=}")
-                # print(f"{dA_cumsum_x[-1, -1]=}")
-                # print(f"{dt_out[-1, -1]=}")
-                # print(f"{dt_out_x[-1, -1]=}")
-                # print(f"{block_states[-1, -1, -1]=}")
-                # print(f"{block_states_x[-1, -1, -1]=}")
-                # print(f"{CB[-1, -1, -1]=}")
-                # print(f"{CB_x[-1, -1, -1]=}")
-
-                # final_states, block_states = state_passing(
-                #     dA_cumsum=dA_cumsum,
-                #     block_states=block_states,
-                #     initial_states=initial_states,
-                #     block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                #     block_req_idx=mamba2_metadata.block_req_idx,
-                #     req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
-                #     return_prev_states=True,
-                #     out_dtype=C_p.dtype,
-                #     align_blocks=align_blocks,
-                #     block_packed_cu_seqlens=mamba2_metadata.
-                #     block_packed_cu_seqlens,
-                # )
-
-                # # Give pre-computed block_states
-                # _, scan_output, _ = fused_block_scan(
-                #     x=x_p,
-                #     dt=dt_out,
-                #     dA_cumsum=dA_cumsum,
-                #     block_states=block_states,
-                #     initial_states=initial_states,
-                #     C=C_p,
-                #     D=self.D,
-                #     CB=CB_x,
-                #     block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                #     block_req_idx=mamba2_metadata.block_req_idx,
-                #     req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
-                #     return_prev_states=False,
-                #     fused_state_passing=False,
-                # )
 
                 # Fused state passing - Confirmed working
                 final_states, scan_output, _ = fused_block_scan(
@@ -658,28 +592,13 @@ class MambaMixer2(CustomOp):
                     initial_states=initial_states,
                     C=C_p,
                     D=self.D,
-                    CB=CB_x,
+                    CB=CB,
                     block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
                     block_req_idx=mamba2_metadata.block_req_idx,
                     req_cu_nblocks=mamba2_metadata.req_cu_nblocks,
                     return_prev_states=False,
                     fused_state_passing=True,
                 )
-
-                # scan_output = block_scan(
-                #     x=x_p,
-                #     dt=dt_out,
-                #     dA_cumsum=dA_cumsum,
-                #     prev_states=block_states,
-                #     C=C_p,
-                #     D=self.D,
-                #     CB=CB_x,
-                #     block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
-                #     align_blocks=align_blocks,
-                #     block_packed_cu_seqlens=mamba2_metadata.
-                #     block_packed_cu_seqlens,
-                # )
-
             else:  # 4 kernel control flow
                 align_blocks = True
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -615,24 +615,24 @@ class MambaMixer2(CustomOp):
                 block_packed_cu_seqlens,
             )
 
-            def restore_packed(x, block_cu_seqlens, block_ntokens):
-                out = []
-                xT = x.T
-                for s, ntokens in zip(block_cu_seqlens[:-1], block_ntokens):
-                    out.append(xT[s:(s + ntokens)])
-                return torch.vstack(out).T
+            # def restore_packed(x, block_cu_seqlens, block_ntokens):
+            #     out = []
+            #     xT = x.T
+            #     for s, ntokens in zip(block_cu_seqlens[:-1], block_ntokens):
+            #         out.append(xT[s:(s + ntokens)])
+            #     return torch.vstack(out).T
 
-            # print(f"{mamba2_metadata.packed_seqlen=}")
-            # print(f"before {dA_cumsum[-1]=}, {dA_cumsum.shape=}")
-            dA_cumsum = restore_packed(dA_cumsum,
-                                       mamba2_metadata.block_packed_cu_seqlens,
-                                       mamba2_metadata.block_ntokens)
-            dt_out = restore_packed(dt_out,
-                                    mamba2_metadata.block_packed_cu_seqlens,
-                                    mamba2_metadata.block_ntokens)
-            # print(f"{dA_cumsum[-1]=}, {dA_cumsum.shape=}")
+            # # print(f"{mamba2_metadata.packed_seqlen=}")
+            # # print(f"before {dA_cumsum[-1]=}, {dA_cumsum.shape=}")
+            # dA_cumsum = restore_packed(dA_cumsum,
+            #                          mamba2_metadata.block_packed_cu_seqlens,
+            #                          mamba2_metadata.block_ntokens)
+            # dt_out = restore_packed(dt_out,
+            #                         mamba2_metadata.block_packed_cu_seqlens,
+            #                         mamba2_metadata.block_ntokens)
+            # # print(f"{dA_cumsum[-1]=}, {dA_cumsum.shape=}")
 
-            align_blocks = False
+            # align_blocks = False
 
             # _, scan_output, _ = fused_block_scan(
             #     x=x_p,
@@ -659,6 +659,8 @@ class MambaMixer2(CustomOp):
                 CB=CB,
                 block_cu_seqlens=mamba2_metadata.block_cu_seqlens,
                 align_blocks=align_blocks,
+                block_packed_cu_seqlens=mamba2_metadata.
+                block_packed_cu_seqlens,
             )
             varlen_states = final_states.to(torch.float16)
 


### PR DESCRIPTION
This PR include changes and performance tweaks 

Most importantly, the PR makes the intermediate tensors `dt` and `dA_cumsum` be 16 byte aligned at block starting position. This improves  the performance of block scan kernel to match the original chunk_scan_fwd kernel

<img width="325" alt="image" src="https://github.com/user-attachments/assets/c9fabe43-c410-4d0d-96e5-d03515a7e711" />

- [x] Fix max_fused path that uses the 2 kernel solution. Right now it fails lm_eval